### PR TITLE
Update version check handling to remove kpsfupdatechecker dependency

### DIFF
--- a/Disambiguator/Disambiguator.cs
+++ b/Disambiguator/Disambiguator.cs
@@ -39,7 +39,7 @@ namespace Disambiguator
 
 		public override string UpdateUrl
 		{
-			get { return "sourceforge-version://Disambiguator/appmatch?-v(%5B%5Cd.%5D%2B)%5C.zip"; }
+			get { return "https://github.com/drventure/Disambiguator/raw/master/VERSION"; }
 		}
 
 

--- a/PackageRelease.bat
+++ b/PackageRelease.bat
@@ -9,6 +9,16 @@ set version=%1
 set buildoutputs=%~dp0Releases\Build Outputs
 set output=%~dp0Releases\v%version%
 set zipfile=%output%\Disambiguator-v%version%.zip
+set versionfile=%~dp0VERSION
+
+echo Writing VERSION file
+for /F "delims=. tokens=1,2,3,4" %%J in ("%version%") do (set major=%%J&set minor=%%K&set patch=%%L&if [%%M]==[] (set build=0) else set build=%%M)
+(
+    @echo :
+    @echo|set /p= The Disambiguator:%major%.%minor%.%patch%
+        if not %build%==0 (@echo .%build%) ELSE (@echo.)
+    @echo|set /p= :
+)>"%versionfile%"
 
 echo Remove Output Version folder %output% to start fresh
 if exist "%output%\NUL" rmdir /s /q "%output%"
@@ -17,8 +27,10 @@ pushd "%buildoutputs%"
 "%ProgramFiles%\7-Zip\7z.exe" a -tzip -mx9 -bd "%zipfile%" *
 popd
 copy "%~dp0Readme.txt" "%output%\"
+copy "%~dp0VERSION" "%output%\"
 
 set version=
 set output=
 set zipfile=
 set buildoutputs=
+set versionfile=


### PR DESCRIPTION
I never really managed to get kpsfupdatechecker to work properly, though I didn't really try.
I took a look at how other plugins are handling version checking and did my best to implement it into your existing release workflow.

- Added version file generation to the release packaging script
- Changed UpdateUrl string property to point to the main repo @ "drventure/Disambiguator/VERSION" file that will be generated by the packaging script